### PR TITLE
[4.1.4] Fix Android camera not appearing after background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [4.1.4] (2023-02-20)
+
+### Fixed 
+* [Android] Fix camera not showing when returning from background and closing and opening it again.
+
 ## [4.1.3] (2023-02-20)
 ### Changed 
 * [iOS] position (x,y) now its ignored in iOS devices and its automatically centered in the middle of the screen

--- a/android/src/main/java/com/ahm/capacitor/camera/preview/CameraActivity.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/CameraActivity.java
@@ -68,6 +68,8 @@ public class CameraActivity extends Fragment {
     public FrameLayout mainLayout;
     public FrameLayout frameContainerLayout;
 
+    public boolean executeIfCameraWasPaused = true;
+
     private Preview mPreview;
     private boolean canTakePicture = true;
 
@@ -327,29 +329,35 @@ public class CameraActivity extends Fragment {
 
     @Override
     public void onResume() {
-        super.onResume();
+      super.onResume();
 
-        mCamera = Camera.open(defaultCameraId);
+      mCamera = Camera.open(defaultCameraId);
 
-        if (cameraParameters != null) {
+      if (cameraParameters != null) {
             mCamera.setParameters(cameraParameters);
-        }
+      }
 
-        cameraCurrentlyLocked = defaultCameraId;
+      cameraCurrentlyLocked = defaultCameraId;
 
-        if (mPreview.mPreviewSize == null) {
+      if (mPreview.mPreviewSize == null) {
             mPreview.setCamera(mCamera, cameraCurrentlyLocked);
             eventListener.onCameraStarted();
-        } else {
+      } else {
             mPreview.switchCamera(mCamera, cameraCurrentlyLocked);
             mCamera.startPreview();
-        }
+      }
 
-        Log.d(TAG, "cameraCurrentlyLocked:" + cameraCurrentlyLocked);
+      if (!executeIfCameraWasPaused) {
+        mPreview.recreatePreviousCameraLayout();
+        mPreview.startCamera();
+      }
 
-        final FrameLayout frameContainerLayout = (FrameLayout) view.findViewById(
-            getResources().getIdentifier("frame_container", "id", appResourcesPackage)
-        );
+
+      Log.d(TAG, "cameraCurrentlyLocked:" + cameraCurrentlyLocked);
+
+      final FrameLayout frameContainerLayout = (FrameLayout) view.findViewById(
+          getResources().getIdentifier("frame_container", "id", appResourcesPackage)
+      );
 
         ViewTreeObserver viewTreeObserver = frameContainerLayout.getViewTreeObserver();
 
@@ -382,6 +390,8 @@ public class CameraActivity extends Fragment {
     @Override
     public void onPause() {
         super.onPause();
+
+        executeIfCameraWasPaused = false;
 
         // Because the Camera object is a shared resource, it's very important to release it when the activity is paused.
         if (mCamera != null) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cotecna/camera-preview",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "description": "Camera preview",
   "main": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",


### PR DESCRIPTION
Add method to recreate previous camera layout in onResume if the camera was paused in any moment.

For some reason the onSurfaceCreated is not executed when opening the plugin again if we leave the plugin in background the first time we opened it, so this method replicates the previous onSurfaceCreated and onLayout behaviour