### PR TITLE
[4.1.5] Fix camera orientation crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [4.1.5] (2023-02-20)
+
+### Fixed 
+* [Android] Fix when tapping too fast in change orientation button it crashed the app.
+
 ## [4.1.4] (2023-02-20)
 
 ### Fixed 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [4.1.5] (2023-02-20)
+## [4.1.5] (2023-03-03)
 
 ### Fixed 
 * [Android] Fix when tapping too fast in change orientation button it crashed the app.

--- a/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
+++ b/android/src/main/java/com/ahm/capacitor/camera/preview/CameraPreview.java
@@ -191,6 +191,12 @@ public class CameraPreview extends Plugin implements CameraActivity.CameraPrevie
 
         List<String> supportedFlashModes;
         supportedFlashModes = camera.getParameters().getSupportedFlashModes();
+
+        if (supportedFlashModes == null) {
+            call.reject("There are no flashModes availables");
+            return;
+        }
+
         if (supportedFlashModes.indexOf(flashMode) > -1) {
             params.setFlashMode(flashMode);
         } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cotecna/camera-preview",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "description": "Camera preview",
   "main": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",


### PR DESCRIPTION
FIX: When tapping to fast in change orientation button it crashed the app